### PR TITLE
feat: add global exception handler with error response DTO

### DIFF
--- a/src/main/java/com/ltphat/task_management/application/dtos/shared/ErrorResponse.java
+++ b/src/main/java/com/ltphat/task_management/application/dtos/shared/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.ltphat.task_management.application.dtos.shared;
+
+import lombok.Data;
+
+@Data
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private long timestamp;
+
+}

--- a/src/main/java/com/ltphat/task_management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ltphat/task_management/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.ltphat.task_management.exception;
+
+import com.ltphat.task_management.application.dtos.shared.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        errorResponse.setMessage(ex.getMessage());
+        errorResponse.setTimestamp(System.currentTimeMillis());
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+}


### PR DESCRIPTION
Introduce a GlobalExceptionHandler to handle all uncaught exceptions
in a centralized manner. Create an ErrorResponse DTO to standardize
error responses with status, message, and timestamp fields. This improves
error handling consistency and provides clearer feedback to API clients.