### PR TITLE
feat(task-service): handle null task page in search results

### DIFF
--- a/src/main/java/com/ltphat/task_management/application/dtos/shared/PagedResponseDto.java
+++ b/src/main/java/com/ltphat/task_management/application/dtos/shared/PagedResponseDto.java
@@ -17,4 +17,8 @@ public class PagedResponseDto<T> {
         this.totalPages = totalPages;
         this.totalItems = totalItems;
     }
+
+    public List<T> getContent() {
+        return items;
+    }
 }

--- a/src/main/java/com/ltphat/task_management/application/dtos/task/TaskRequestDto.java
+++ b/src/main/java/com/ltphat/task_management/application/dtos/task/TaskRequestDto.java
@@ -1,8 +1,12 @@
 package com.ltphat.task_management.application.dtos.task;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class TaskRequestDto {
     private String name;
     private String description;

--- a/src/main/java/com/ltphat/task_management/application/dtos/task/TaskResponseDto.java
+++ b/src/main/java/com/ltphat/task_management/application/dtos/task/TaskResponseDto.java
@@ -1,8 +1,12 @@
 package com.ltphat.task_management.application.dtos.task;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class TaskResponseDto {
     private Long id;
     private String name;

--- a/src/main/java/com/ltphat/task_management/application/services/TaskService.java
+++ b/src/main/java/com/ltphat/task_management/application/services/TaskService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -35,6 +36,10 @@ public class TaskService {
             tasksPage = taskRepository.findAll(pageable);
         } else {
             tasksPage = taskRepository.findByNameContainingIgnoreCase(search, pageable);
+        }
+
+        if (tasksPage == null) {
+            return new PagedResponseDto<>(Collections.emptyList(), 1, 1, 0);
         }
 
         List<TaskResponseDto> taskDtos = tasksPage.map(taskMapper::taskToTaskResponseDto).getContent();

--- a/src/test/java/com/ltphat/task_management/application/services/TaskServiceTest.java
+++ b/src/test/java/com/ltphat/task_management/application/services/TaskServiceTest.java
@@ -1,0 +1,126 @@
+package com.ltphat.task_management.application.services;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ltphat.task_management.application.dtos.shared.PagedResponseDto;
+import com.ltphat.task_management.application.mappers.TaskMapper;
+import com.ltphat.task_management.domain.model.Task;
+import com.ltphat.task_management.domain.repository.TaskRepository;
+import com.ltphat.task_management.application.dtos.task.TaskRequestDto;
+import com.ltphat.task_management.application.dtos.task.TaskResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private TaskMapper taskMapper;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    private Task task;
+    private TaskRequestDto taskRequestDto;
+    private TaskResponseDto taskResponseDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        task = new Task(1L, "Task 1", "Description of Task 1", "Pending");
+        taskRequestDto = new TaskRequestDto("Task 1", "Description of Task 1", "Pending");
+        taskResponseDto = new TaskResponseDto(1L, "Task 1", "Description of Task 1", "Pending");
+    }
+
+    @Test
+    @Order(1)
+    void testCreateTask() {
+        // Mocking the repository and mapper
+        when(taskRepository.save(any(Task.class))).thenReturn(task);
+        when(taskMapper.taskRequestDtoToTask(any(TaskRequestDto.class))).thenReturn(task);
+        when(taskMapper.taskToTaskResponseDto(any(Task.class))).thenReturn(taskResponseDto);
+
+        // Call the service method
+        TaskResponseDto createdTask = taskService.createTask(taskRequestDto);
+
+        // Verifying the result
+        assertNotNull(createdTask);
+        assertEquals("Task 1", createdTask.getName());
+        assertEquals("Pending", createdTask.getStatus());
+        verify(taskRepository, times(1)).save(any(Task.class));  // Verifying repository save method was called
+    }
+
+    @Test
+    @Order(2)
+    void testGetAllTasks() {
+        // Arrange: Create a Pageable instance and a valid Page containing tasks
+        Pageable pageable = PageRequest.of(0, 5); // Creates a Pageable with page 0, size 5
+        List<Task> tasks = Arrays.asList(task); // A list of tasks
+        PageImpl<Task> taskPage = new PageImpl<>(tasks, pageable, tasks.size()); // Creating PageImpl with tasks
+
+        // Mocking the repository to return a Page of tasks when findAll is called
+        when(taskRepository.findAll(pageable)).thenReturn(taskPage);
+
+        // Mocking the mapper to convert a task to TaskResponseDto
+        when(taskMapper.taskToTaskResponseDto(any(Task.class))).thenReturn(taskResponseDto);
+
+        // Act: Call the service method to get all tasks
+        PagedResponseDto<TaskResponseDto> pagedResponseDto = taskService.getAllTasks("", "name", "asc", 0, 5);
+
+        // Extracting the list of TaskResponseDto from the PagedResponseDto
+        List<TaskResponseDto> taskDtos = pagedResponseDto.getContent();
+
+        // Assert: Check that the result is not null and the content matches expectations
+        assertNotNull(taskDtos);
+        assertEquals(1, taskDtos.size());
+        assertEquals("Task 1", taskDtos.get(0).getName());
+
+        // Verify interactions with the mocks
+        verify(taskRepository, times(1)).findAll(pageable); // Verify the repository's findAll method is called once
+        verify(taskMapper, times(1)).taskToTaskResponseDto(any(Task.class)); // Verify the mapper's method is called once
+    }
+
+    @Test
+    void testUpdateTask() {
+        // Mocking the repository behavior
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskRepository.save(any(Task.class))).thenReturn(task);
+        when(taskMapper.taskToTaskResponseDto(any(Task.class))).thenReturn(taskResponseDto);
+
+        // Call the service method
+        TaskResponseDto updatedTask = taskService.updateTask(1L, taskRequestDto);
+
+        // Verifying the result
+        assertNotNull(updatedTask);
+        assertEquals("Task 1", updatedTask.getName());
+        verify(taskRepository, times(1)).findById(1L);  // Verifying repository findById method was called
+        verify(taskRepository, times(1)).save(any(Task.class));  // Verifying repository save method was called
+    }
+
+    @Test
+    void testDeleteTask() {
+        // Mocking repository behavior
+        doNothing().when(taskRepository).deleteById(1L);
+
+        // Call the service method
+        taskService.deleteTask(1L);
+
+        // Verifying the repository's delete method was called
+        verify(taskRepository, times(1)).deleteById(1L);
+    }
+}
+

--- a/src/test/java/com/ltphat/task_management/domain/repository/TaskRepositoryTest.java
+++ b/src/test/java/com/ltphat/task_management/domain/repository/TaskRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.ltphat.task_management.domain.repository;
+
+import com.ltphat.task_management.domain.model.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+public class TaskRepositoryTest {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    private Task task;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        task = new Task(1L, "Task 1", "Description of Task 1", "Pending");
+        taskRepository.save(task);
+    }
+
+    @Test
+    void testFindByNameContainingIgnoreCase() {
+        var pageable = PageRequest.of(0, 5);
+        var tasks = taskRepository.findByNameContainingIgnoreCase("task", pageable);
+
+        assertNotNull(tasks);
+        assertFalse(tasks.isEmpty());
+        assertEquals("Task 1", tasks.getContent().get(0).getName());
+    }
+
+    @Test
+    void testFindById() {
+        var foundTask = taskRepository.findById(1L);
+
+        assertTrue(foundTask.isPresent());
+        assertEquals("Task 1", foundTask.get().getName());
+    }
+}
+

--- a/src/test/java/com/ltphat/task_management/interfaces/api/TaskControllerTest.java
+++ b/src/test/java/com/ltphat/task_management/interfaces/api/TaskControllerTest.java
@@ -1,0 +1,79 @@
+package com.ltphat.task_management.interfaces.api;
+
+import com.ltphat.task_management.application.dtos.shared.PagedResponseDto;
+import com.ltphat.task_management.application.dtos.task.TaskRequestDto;
+import com.ltphat.task_management.application.dtos.task.TaskResponseDto;
+import com.ltphat.task_management.application.services.TaskService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class TaskControllerTest {
+    @Mock
+    private TaskService taskService;
+
+    @InjectMocks
+    private TaskController taskRestController;
+
+    private MockMvc mockMvc;
+
+    private TaskRequestDto taskRequestDto;
+    private TaskResponseDto taskResponseDto;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(taskRestController).build();
+
+        taskRequestDto = new TaskRequestDto("Task 1", "Description of Task 1", "Pending");
+        taskResponseDto = new TaskResponseDto(1L, "Task 1", "Description of Task 1", "Pending");
+    }
+
+    @Test
+    void testCreateTask() throws Exception {
+        when(taskService.createTask(any(TaskRequestDto.class))).thenReturn(taskResponseDto);
+
+        mockMvc.perform(post("/tasks")
+                        .contentType("application/json")
+                        .content("{\"name\":\"Task 1\", \"description\":\"Description of Task 1\", \"status\":\"Pending\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Task 1"))
+                .andExpect(jsonPath("$.status").value("Pending"));
+
+        verify(taskService, times(1)).createTask(any(TaskRequestDto.class));
+    }
+
+    @Test
+    void testGetAllTasks() throws Exception {
+        // Mocking the service response
+        PagedResponseDto<TaskResponseDto> pagedResponseDto = new PagedResponseDto<>(
+                List.of(taskResponseDto),  // List of task DTOs
+                0,  // currentPage
+                1,  // totalPages
+                1   // totalItems
+        );
+
+        // Mock the service call
+        when(taskService.getAllTasks("", "name", "asc", 0, 5)).thenReturn(pagedResponseDto);
+
+        // Perform the GET request to /tasks with query parameters
+        mockMvc.perform(get("/tasks?page=0&size=5"))
+                .andExpect(status().isOk())  // Check for OK response
+                .andExpect(jsonPath("$.content[0].name").value("Task 1"))  // Check task name in content
+                .andExpect(jsonPath("$.content[0].status").value("Pending"))  // Check task status in content
+                .andExpect(jsonPath("$.currentPage").value(0))  // Check currentPage
+                .andExpect(jsonPath("$.totalPages").value(1))  // Check totalPages
+                .andExpect(jsonPath("$.totalItems").value(1));  // Check totalItems
+
+        // Verify that the service method was called exactly once
+        verify(taskService, times(1)).getAllTasks("", "name", "asc", 0, 5);
+    }
+}


### PR DESCRIPTION
Return an empty paged response when taskRepository returns null to
prevent potential NullPointerExceptions and improve robustness of
task retrieval.

test: add repository and controller tests for task operations

Add TaskRepositoryTest to verify task queries and TaskControllerTest
to validate REST endpoints, ensuring correctness of task creation
and retrieval APIs.